### PR TITLE
add extra parameters for pysam.tabix_index()

### DIFF
--- a/docs/Format.md
+++ b/docs/Format.md
@@ -14,29 +14,30 @@ GWASLab provides a flexible formatting and saving function.
 
 ## 2. Options
 
-|`.to_format()` options|DataType|Description|Default|
-|-|-|-|-|
-|`path`|`string`|the path for the output file; only prefix is needed.|`"./sumstats"`|
-|`fmt`|`string`|output format for sumstats. Currently support `plink` ,`plink2`, `ldsc`, `saige`, `fastgwa`, `regenie` and so forth. For details , please check [ https://github.com/Cloufield/formatbook](https://github.com/Cloufield/formatbook).|`"gwaslab"`|
-|`cols`|`list`|list of additional columns to linclude in the output|`None`|
-|`extract`|`list`|a list of variant SNPIDs to include.|`None`|
-|`exclude`|`list`|a list of variant SNPIDs to exclude.|`None`|
-|`id_use`|`SNPID` or `rsID`| specify which ID to use when excluding or extracting variants.|`rsID`|
-|`hapmap3`|`boolean`|If True, only output Hapmap3 SNPs.|`False`|
-|`exclude_hla`|`boolean`|if True, exclude variants in the MHC region from the output.|`False`|
-|`hla_range`|`tuple`|a tuple of 2 numbers (MBp) indicating the start and the end position of the HLA region. |`(25,34)`|
-|`build`|`string`| reference genome build.|`"19"`|
-|`xymt_number`|`boolean`|if True, output sex chromosomes as X/Y/MT |"False"|
-|`xymt`|`list`| 3-element list of sex chromosome notations to indicate how to convert integers to sex chromosome|`["X","Y","MT"]`|
-|`chr_prefix`|`string`|Add a prefix to chromosomes. For example, 6 -> Chr6.|`""`|
-|`bgzip`|`boolean`|If True, bgzip the output file. Only works for bed and vcf format.|-|
-|`tabix`|`boolean`|If True, use tabix to index the bgzipped output file. Only works for bed and vcf format.|-|
-|`md5sum`|`boolean`|If True, calculate and outpit the file MD5 hashes|`False`|
-|`to_csvargs`|`dict`|extra parameters for pd.to_csv()|`None`|
-|`float_formats`|`dict`|a dictionary to specify the float format for each column.|`None`|
-|`verbose`|`boolean`|If True, print logs.|`True`|
-|`output_log`|`boolean`|If True, save the log to a file.|`True`|
-|`ssfmeta`|`boolean`|If True, output a gwas-ssf-style meta file.|`False`|
+| `.to_format()` options | DataType          | Description                                                                                                                                                                                                                          | Default          |
+|------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| `path`                 | `string`          | the path for the output file; only prefix is needed.                                                                                                                                                                                 | `"./sumstats"`   |
+| `fmt`                  | `string`          | output format for sumstats. Currently support `plink` ,`plink2`, `ldsc`, `saige`, `fastgwa`, `regenie` and so forth. For details , please check [ https://github.com/Cloufield/formatbook](https://github.com/Cloufield/formatbook). | `"gwaslab"`      |
+| `cols`                 | `list`            | list of additional columns to linclude in the output                                                                                                                                                                                 | `None`           |
+| `extract`              | `list`            | a list of variant SNPIDs to include.                                                                                                                                                                                                 | `None`           |
+| `exclude`              | `list`            | a list of variant SNPIDs to exclude.                                                                                                                                                                                                 | `None`           |
+| `id_use`               | `SNPID` or `rsID` | specify which ID to use when excluding or extracting variants.                                                                                                                                                                       | `rsID`           |
+| `hapmap3`              | `boolean`         | If True, only output Hapmap3 SNPs.                                                                                                                                                                                                   | `False`          |
+| `exclude_hla`          | `boolean`         | if True, exclude variants in the MHC region from the output.                                                                                                                                                                         | `False`          |
+| `hla_range`            | `tuple`           | a tuple of 2 numbers (MBp) indicating the start and the end position of the HLA region.                                                                                                                                              | `(25,34)`        |
+| `build`                | `string`          | reference genome build.                                                                                                                                                                                                              | `"19"`           |
+| `xymt_number`          | `boolean`         | if True, output sex chromosomes as X/Y/MT                                                                                                                                                                                            | "False"          |
+| `xymt`                 | `list`            | 3-element list of sex chromosome notations to indicate how to convert integers to sex chromosome                                                                                                                                     | `["X","Y","MT"]` |
+| `chr_prefix`           | `string`          | Add a prefix to chromosomes. For example, 6 -> Chr6.                                                                                                                                                                                 | `""`             |
+| `bgzip`                | `boolean`         | If True, bgzip the output file. Only works for bed and vcf format.                                                                                                                                                                   | -                |
+| `tabix`                | `boolean`         | If True, use tabix to index the bgzipped output file. Only works for bed and vcf format.                                                                                                                                             | -                |
+| `tabix_indexargs`      | `dict`            | extra parameters for pysam.tabix_index()                                                                                                                                                                                             | `{}`             |
+| `md5sum`               | `boolean`         | If True, calculate and output the file MD5 hashes                                                                                                                                                                                    | `False`          |
+| `to_csvargs`           | `dict`            | extra parameters for pd.to_csv()                                                                                                                                                                                                     | `None`           |
+| `float_formats`        | `dict`            | a dictionary to specify the float format for each column.                                                                                                                                                                            | `None`           |
+| `verbose`              | `boolean`         | If True, print logs.                                                                                                                                                                                                                 | `True`           |
+| `output_log`           | `boolean`         | If True, save the log to a file.                                                                                                                                                                                                     | `True`           |
+| `ssfmeta`              | `boolean`         | If True, output a gwas-ssf-style meta file.                                                                                                                                                                                          | `False`          |
 
 ## 3. Format dictionary
 

--- a/src/gwaslab/Sumstats.py
+++ b/src/gwaslab/Sumstats.py
@@ -619,7 +619,8 @@ class Sumstats():
               ssfmeta=False,
               md5sum=False,
               bgzip=False,
-              tabix=False):
+              tabix=False,
+              tabix_indexargs={}):
         
         onetime_log = copy.deepcopy(self.log)
         if  to_csvargs is None:
@@ -726,6 +727,7 @@ class Sumstats():
                   ssfmeta=ssfmeta,
                   bgzip=bgzip,
                   tabix=tabix,
+                  tabix_indexargs=tabix_indexargs,
                   md5sum=md5sum,
                   xymt_number=xymt_number,
                   xymt=xymt)

--- a/src/gwaslab/to_formats.py
+++ b/src/gwaslab/to_formats.py
@@ -35,6 +35,7 @@ def tofmt(sumstats,
           md5sum=False,
           bgzip=False,
           tabix=False,
+          tabix_indexargs={},
           verbose=True,
           no_status=False,
           log=Log(),
@@ -125,8 +126,13 @@ def tofmt(sumstats,
             if verbose: log.write(" -bgzip compressing ...") 
             tabix_compress(path, path+".gz",force=True)
         if tabix is True:
-            if verbose: log.write(" -tabix indexing...") 
-            tabix_index(path+".gz" ,preset="bed",force=True) 
+            if verbose: log.write(" -tabix indexing...")
+            if "preset" not in  tabix_indexargs:
+                tabix_indexargs["preset"] = "bed"
+            if "force" not in tabix_indexargs:
+                tabix_indexargs["force"] = True
+
+            tabix_index(path+".gz", **tabix_indexargs)
     ####################################################################################################################   
     elif fmt=="vep":
         # bed-like format, 1-based
@@ -231,8 +237,12 @@ def tofmt(sumstats,
             tabix_compress(path, path+".gz",force=True)
             if md5sum is True: md5sum_file(path+".gz",log,verbose)
         if tabix is True:
-            if verbose: log.write(" -tabix indexing...") 
-            tabix_index(path+".gz" ,preset="bed",force=True) 
+            if verbose: log.write(" -tabix indexing...")
+            if "preset" not in tabix_indexargs:
+                tabix_indexargs["preset"] = "bed"
+            if "force" not in tabix_indexargs:
+                tabix_indexargs["force"] = True
+            tabix_index(path+".gz", **tabix_indexargs)
     ####################################################################################################################       
     elif fmt=="vcf":
         if verbose: log.write(" -"+fmt+" format will be loaded...")
@@ -334,8 +344,12 @@ def tofmt(sumstats,
             tabix_compress(path, path+".gz",force=True)
             if md5sum is True: md5sum_file(path+".gz",log,verbose)
         if tabix==True:
-            if verbose: log.write(" -tabix indexing...") 
-            tabix_index(path+".gz" ,preset="vcf",force=True) 
+            if verbose: log.write(" -tabix indexing...")
+            if "preset" not in tabix_indexargs:
+                tabix_indexargs["preset"] = "vcf"
+            if "force" not in tabix_indexargs:
+                tabix_indexargs["force"] = True
+            tabix_index(path+".gz", **tabix_indexargs)
     ####################################################################################################################
     elif fmt in get_formats_list():       
         if verbose: log.write(" -"+fmt+" format will be loaded...")


### PR DESCRIPTION
This PR would like to add the ability to pass additional parameters to the pysam.tabix_index function called by the .to_format function, e.g:

`mysumstats.to_format("./test", fmt="vcf", bgzip=True, tabix=True, tabix_indexargs={'csi': True}, build="38")`