### PR TITLE
Fix missing logs, rename **args to **kwargs, fix typo

### DIFF
--- a/src/gwaslab/g_Sumstats.py
+++ b/src/gwaslab/g_Sumstats.py
@@ -240,15 +240,15 @@ class Sumstats():
         self.data, self.meta["gwaslab"]["genome_build"] = _set_build(self.data, build=build, log=self.log,verbose=verbose)
         gc.collect()
 
-    def infer_build(self,**args):
-        self.data, self.meta["gwaslab"]["genome_build"] = inferbuild(self.data,**args)
+    def infer_build(self,verbose=True,**kwargs):
+        self.data, self.meta["gwaslab"]["genome_build"] = inferbuild(self.data,log=self.log,verbose=verbose,**kwargs)
     
-    def liftover(self,to_build, from_build=None,**args):
+    def liftover(self,to_build, from_build=None,**kwargs):
         if from_build is None:
             if self.meta["gwaslab"]["genome_build"]=="99":
-                self.data, self.meta["gwaslab"]["genome_build"] = inferbuild(self.data,**args)
+                self.data, self.meta["gwaslab"]["genome_build"] = inferbuild(self.data,**kwargs)
             from_build = self.meta["gwaslab"]["genome_build"]
-        self.data = parallelizeliftovervariant(self.data,from_build=from_build, to_build=to_build, log=self.log,**args)
+        self.data = parallelizeliftovervariant(self.data,from_build=from_build, to_build=to_build, log=self.log,**kwargs)
         self.meta["is_sorted"] = False
         self.meta["is_harmonised"] = False
         self.meta["gwaslab"]["genome_build"]=to_build
@@ -261,7 +261,7 @@ class Sumstats():
                     n_cores=1,
                     fixid_args={},
                     removedup_args={},
-                    fixchr_agrs={},
+                    fixchr_args={},
                     fixpos_args={},
                     fixallele_args={},
                     sanitycheckstats_args={},
@@ -271,8 +271,8 @@ class Sumstats():
                     verbose=True):
         ###############################################
         # try to fix data without dropping any information
-        self.data = fixID(self.data,verbose=verbose, **fixid_args)
-        self.data = fixchr(self.data,log=self.log,remove=remove,verbose=verbose,**fixchr_agrs)
+        self.data = fixID(self.data,log=self.log,verbose=verbose, **fixid_args)
+        self.data = fixchr(self.data,log=self.log,remove=remove,verbose=verbose,**fixchr_args)
         self.data = fixpos(self.data,log=self.log,remove=remove,verbose=verbose,**fixpos_args)
         self.data = fixallele(self.data,log=self.log,remove=remove,verbose=verbose,**fixallele_args)
         self.data = sanitycheckstats(self.data,log=self.log,verbose=verbose,**sanitycheckstats_args)
@@ -306,7 +306,7 @@ class Sumstats():
               flipallelestats_args={},
               liftover_args={},
               fixid_args={},
-              fixchr_agrs={},
+              fixchr_args={},
               fixpos_args={},
               fixallele_args={},
               sanitycheckstats_args={},
@@ -324,9 +324,9 @@ class Sumstats():
         #    1.6 sorting genomic coordinates and column order 
         if basic_check is True:
             
-            self.data = fixID(self.data,**fixid_args)
+            self.data = fixID(self.data,log=self.log,**fixid_args)
             
-            self.data = fixchr(self.data,remove=remove,log=self.log,**fixchr_agrs)
+            self.data = fixchr(self.data,remove=remove,log=self.log,**fixchr_args)
             
             self.data = fixpos(self.data,remove=remove,log=self.log,**fixpos_args)
             
@@ -409,183 +409,183 @@ class Sumstats():
         return self
     ############################################################################################################
     #customizable API to build your own QC pipeline
-    def fix_id(self,**args):
-        self.data = fixID(self.data,log=self.log,**args)
-    def fix_chr(self,**args):
-        self.data = fixchr(self.data,log=self.log,**args)
-    def fix_pos(self,**args):
-        self.data = fixpos(self.data,log=self.log,**args)
-    def fix_allele(self,**args):
-        self.data = fixallele(self.data,log=self.log,**args)
-    def remove_dup(self,**args):
-        self.data = removedup(self.data,log=self.log,**args)
-    def check_sanity(self,**args):
-        self.data = sanitycheckstats(self.data,log=self.log,**args)
-    def check_data_consistency(self, **args):
-        _check_data_consistency(self.data,log=self.log,**args)
-    def check_id(self,**args):
+    def fix_id(self,**kwargs):
+        self.data = fixID(self.data,log=self.log,**kwargs)
+    def fix_chr(self,**kwargs):
+        self.data = fixchr(self.data,log=self.log,**kwargs)
+    def fix_pos(self,**kwargs):
+        self.data = fixpos(self.data,log=self.log,**kwargs)
+    def fix_allele(self,**kwargs):
+        self.data = fixallele(self.data,log=self.log,**kwargs)
+    def remove_dup(self,**kwargs):
+        self.data = removedup(self.data,log=self.log,**kwargs)
+    def check_sanity(self,**kwargs):
+        self.data = sanitycheckstats(self.data,log=self.log,**kwargs)
+    def check_data_consistency(self, **kwargs):
+        _check_data_consistency(self.data,log=self.log,**kwargs)
+    def check_id(self,**kwargs):
         pass
-    def check_ref(self,ref_seq,ref_seq_mode="v",**args):
+    def check_ref(self,ref_seq,ref_seq_mode="v",**kwargs):
         if ref_seq_mode=="v":
             self.meta["gwaslab"]["references"]["ref_seq"] = ref_seq
-            self.data = checkref(self.data,ref_seq,log=self.log,**args)
+            self.data = checkref(self.data,ref_seq,log=self.log,**kwargs)
         else:
             self.meta["gwaslab"]["references"]["ref_seq"] = ref_seq
-            self.data = oldcheckref(self.data,ref_seq,log=self.log,**args)            
-    def infer_strand(self,ref_infer,**args):
+            self.data = oldcheckref(self.data,ref_seq,log=self.log,**kwargs)            
+    def infer_strand(self,ref_infer,**kwargs):
         self.meta["gwaslab"]["references"]["ref_infer"] = _append_meta_record(self.meta["gwaslab"]["references"]["ref_infer"] , ref_infer)
-        self.data = parallelinferstrand(self.data,ref_infer=ref_infer,log=self.log,**args)
-    def flip_allele_stats(self,**args):
-        self.data = flipallelestats(self.data,log=self.log,**args)
-    def normalize_allele(self,**args):
-        self.data = parallelnormalizeallele(self.data,log=self.log,**args)
+        self.data = parallelinferstrand(self.data,ref_infer=ref_infer,log=self.log,**kwargs)
+    def flip_allele_stats(self,**kwargs):
+        self.data = flipallelestats(self.data,log=self.log,**kwargs)
+    def normalize_allele(self,**kwargs):
+        self.data = parallelnormalizeallele(self.data,log=self.log,**kwargs)
     def assign_rsid(self,
                     ref_rsid_tsv=None,
                     ref_rsid_vcf=None,
-                    **args):
+                    **kwargs):
         if ref_rsid_tsv is not None:
-            self.data = parallelizeassignrsid(self.data,path=ref_rsid_tsv,ref_mode="tsv",log=self.log,**args)
+            self.data = parallelizeassignrsid(self.data,path=ref_rsid_tsv,ref_mode="tsv",log=self.log,**kwargs)
             self.meta["gwaslab"]["references"]["ref_rsid_tsv"] = ref_rsid_tsv
         if ref_rsid_vcf is not None:
-            self.data = parallelizeassignrsid(self.data,path=ref_rsid_vcf,ref_mode="vcf",log=self.log,**args)   
+            self.data = parallelizeassignrsid(self.data,path=ref_rsid_vcf,ref_mode="vcf",log=self.log,**kwargs)   
             self.meta["gwaslab"]["references"]["ref_rsid_vcf"] = _append_meta_record(self.meta["gwaslab"]["references"]["ref_rsid_vcf"] , ref_rsid_vcf)
-    def rsid_to_chrpos(self,**args):
-        self.data = rsidtochrpos(self.data,log=self.log,**args)
-    def rsid_to_chrpos2(self,**args):
-        self.data = parallelrsidtochrpos(self.data,log=self.log,**args)
+    def rsid_to_chrpos(self,**kwargs):
+        self.data = rsidtochrpos(self.data,log=self.log,**kwargs)
+    def rsid_to_chrpos2(self,**kwargs):
+        self.data = parallelrsidtochrpos(self.data,log=self.log,**kwargs)
 
     ############################################################################################################
     
     def sort_coordinate(self,**sort_args):
         self.data = sortcoordinate(self.data,log=self.log,**sort_args)
         self.meta["is_sorted"] = True
-    def sort_column(self,**args):
-        self.data = sortcolumn(self.data,log=self.log,**args)
+    def sort_column(self,**kwargs):
+        self.data = sortcolumn(self.data,log=self.log,**kwargs)
     
     ############################################################################################################
-    def fill_data(self, verbose=True, **args):
-        self.data = filldata(self.data, verbose=verbose, **args)
+    def fill_data(self, verbose=True, **kwargs):
+        self.data = filldata(self.data, verbose=verbose, log=self.log, **kwargs)
         self.data = sortcolumn(self.data, verbose=verbose, log=self.log)
 
 # utilities ############################################################################################################
     # filter series ######################################################################
-    def filter_flanking(self, inplace=False,**args):
+    def filter_flanking(self, inplace=False,**kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _get_flanking(new_Sumstats_object.data, **args)
+            new_Sumstats_object.data = _get_flanking(new_Sumstats_object.data, **kwargs)
             return new_Sumstats_object
         else:
-            self.data = _get_flanking(self.data, **args)
-    def filter_flanking_by_chrpos(self, chrpos,  inplace=False,**args):
+            self.data = _get_flanking(self.data, **kwargs)
+    def filter_flanking_by_chrpos(self, chrpos,  inplace=False,**kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _get_flanking_by_chrpos(new_Sumstats_object.data, chrpos, **args)
+            new_Sumstats_object.data = _get_flanking_by_chrpos(new_Sumstats_object.data, chrpos, **kwargs)
             return new_Sumstats_object
         else:
-            self.data = _get_flanking_by_chrpos(self.data, chrpos,**args)
-    def filter_flanking_by_id(self, snpid, inplace=False,**args):
+            self.data = _get_flanking_by_chrpos(self.data, chrpos,**kwargs)
+    def filter_flanking_by_id(self, snpid, inplace=False,**kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _get_flanking_by_id(new_Sumstats_object.data, snpid, **args)
+            new_Sumstats_object.data = _get_flanking_by_id(new_Sumstats_object.data, snpid, **kwargs)
             return new_Sumstats_object
         else:
-            self.data = _get_flanking_by_id(self.data, snpid, **args)
-    def filter_value(self, expr, inplace=False, **args):
+            self.data = _get_flanking_by_id(self.data, snpid, **kwargs)
+    def filter_value(self, expr, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filtervalues(new_Sumstats_object.data,expr,log=new_Sumstats_object.log, **args)
+            new_Sumstats_object.data = filtervalues(new_Sumstats_object.data,expr,log=new_Sumstats_object.log, **kwargs)
             return new_Sumstats_object
         else:
-            self.data = filtervalues(self.data, expr,log=self.log,**args)
-    def filter_out(self, inplace=False, **args):
+            self.data = filtervalues(self.data, expr,log=self.log,**kwargs)
+    def filter_out(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filterout(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = filterout(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = filterout(self.data,log=self.log,**args)
-    def filter_in(self, inplace=False, **args):
+            self.data = filterout(self.data,log=self.log,**kwargs)
+    def filter_in(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filterin(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = filterin(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = filterin(self.data,log=self.log,**args)
-    def filter_region_in(self, inplace=False, **args):
+            self.data = filterin(self.data,log=self.log,**kwargs)
+    def filter_region_in(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filterregionin(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = filterregionin(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = filterregionin(self.data,log=self.log,**args)
-    def filter_region_out(self, inplace=False, **args):
+            self.data = filterregionin(self.data,log=self.log,**kwargs)
+    def filter_region_out(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filterregionout(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = filterregionout(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = filterregionout(self.data,log=self.log,**args)
-    def filter_palindromic(self, inplace=False, **args):
+            self.data = filterregionout(self.data,log=self.log,**kwargs)
+    def filter_palindromic(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _filter_palindromic(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = _filter_palindromic(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = _filter_palindromic(self.data,log=self.log,**args)
-    def filter_snp(self, inplace=False, **args):
+            self.data = _filter_palindromic(self.data,log=self.log,**kwargs)
+    def filter_snp(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _filter_snp(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = _filter_snp(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = _filter_snp(self.data,log=self.log,**args)
-    def filter_indel(self, inplace=False, **args):
+            self.data = _filter_snp(self.data,log=self.log,**kwargs)
+    def filter_indel(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _filter_indel(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = _filter_indel(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = _filter_indel(self.data,log=self.log,**args)
+            self.data = _filter_indel(self.data,log=self.log,**kwargs)
     
-    def exclude_hla(self, inplace=False, **args):
+    def exclude_hla(self, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = _exclude_hla(new_Sumstats_object.data,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = _exclude_hla(new_Sumstats_object.data,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         else:
-            self.data = _exclude_hla(self.data,log=self.log,**args)
+            self.data = _exclude_hla(self.data,log=self.log,**kwargs)
 
 
-    def random_variants(self,inplace=False,n=1,p=None,**args):
+    def random_variants(self,inplace=False,n=1,p=None,**kwargs):
         if inplace is True:
-            self.data = sampling(self.data,n=n,p=p,log=self.log,**args)
+            self.data = sampling(self.data,n=n,p=p,log=self.log,**kwargs)
         else:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = sampling(new_Sumstats_object.data,n=n,p=p,log=new_Sumstats_object.log,**args)
+            new_Sumstats_object.data = sampling(new_Sumstats_object.data,n=n,p=p,log=new_Sumstats_object.log,**kwargs)
             return new_Sumstats_object
         
-    def filter_hapmap3(self, inplace=False, build=None, **args ):
+    def filter_hapmap3(self, inplace=False, build=None, **kwargs ):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
         if inplace is True:
-            self.data = gethapmap3(self.data, build=build,log=self.log, **args)
+            self.data = gethapmap3(self.data, build=build,log=self.log, **kwargs)
         else:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = gethapmap3(new_Sumstats_object.data, build=build,log=self.log, **args)
+            new_Sumstats_object.data = gethapmap3(new_Sumstats_object.data, build=build,log=self.log, **kwargs)
             return new_Sumstats_object
     ######################################################################
     
-    def check_af(self,ref_infer,**args):
-        self.data = parallelecheckaf(self.data,ref_infer=ref_infer,log=self.log,**args)
+    def check_af(self,ref_infer,**kwargs):
+        self.data = parallelecheckaf(self.data,ref_infer=ref_infer,log=self.log,**kwargs)
         self.meta["gwaslab"]["references"]["ref_infer_daf"] = _append_meta_record(self.meta["gwaslab"]["references"]["ref_infer_daf"] , ref_infer)
-    def infer_af(self,ref_infer,**args):
-        self.data = paralleleinferaf(self.data,ref_infer=ref_infer,log=self.log,**args)
+    def infer_af(self,ref_infer,**kwargs):
+        self.data = paralleleinferaf(self.data,ref_infer=ref_infer,log=self.log,**kwargs)
         self.meta["gwaslab"]["references"]["ref_infer_af"] = ref_infer
         self.meta["gwaslab"]["references"]["ref_infer_af"] = _append_meta_record(self.meta["gwaslab"]["references"]["ref_infer_af"] , ref_infer)
-    def plot_daf(self, **args):
-        fig,outliers = plotdaf(self.data, **args)
+    def plot_daf(self, **kwargs):
+        fig,outliers = plotdaf(self.data, **kwargs)
         return fig, outliers
-    def plot_mqq(self, build=None, **args):
+    def plot_mqq(self, build=None, **kwargs):
 
         chrom="CHR"
         pos="POS"
@@ -612,17 +612,17 @@ class Sumstats():
                        p=p, 
                        eaf=eaf,
                        build = build, 
-                       **args)
+                       **kwargs)
         
         return plot
     
-    def plot_trumpet(self, build=None, **args):
+    def plot_trumpet(self, build=None, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
-        fig = plottrumpet(self.data,build = build,  **args)
+        fig = plottrumpet(self.data,build = build,  **kwargs)
         return fig
 
-    def get_lead(self, build=None, gls=False, **args):
+    def get_lead(self, build=None, gls=False, **kwargs):
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
         else:
@@ -639,7 +639,7 @@ class Sumstats():
                            p="P",
                            log=self.log,
                            build=build,
-                           **args)
+                           **kwargs)
         # return sumstats object    
         if gls == True:
             new_Sumstats_object = copy.deepcopy(self)
@@ -648,7 +648,7 @@ class Sumstats():
             return new_Sumstats_object
         return output
 
-    def get_density(self, sig_list=None, windowsizekb=100,**args):
+    def get_density(self, sig_list=None, windowsizekb=100,**kwargs):
         
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
@@ -673,7 +673,7 @@ class Sumstats():
                                                     log=self.log)
 
         
-    def get_novel(self, **args):
+    def get_novel(self, **kwargs):
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
         else:
@@ -684,11 +684,11 @@ class Sumstats():
                            pos="POS",
                            p="P",
                            log=self.log,
-                           **args)
+                           **kwargs)
         # return sumstats object    
         return output
     
-    def check_cis(self, **args):
+    def check_cis(self, **kwargs):
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
         else:
@@ -699,11 +699,11 @@ class Sumstats():
                            pos="POS",
                            p="P",
                            log=self.log,
-                           **args)
+                           **kwargs)
         # return sumstats object    
         return output
     
-    def check_novel_set(self, **args):
+    def check_novel_set(self, **kwargs):
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
         else:
@@ -714,11 +714,11 @@ class Sumstats():
                            pos="POS",
                            p="P",
                            log=self.log,
-                           **args)
+                           **kwargs)
         # return sumstats object    
         return output
     
-    def anno_gene(self, **args):
+    def anno_gene(self, **kwargs):
         if "SNPID" in self.data.columns:
             id_to_use = "SNPID"
         else:
@@ -728,73 +728,73 @@ class Sumstats():
                            chrom="CHR",
                            pos="POS",
                            log=self.log,
-                           **args)
+                           **kwargs)
         return output
         
-    def get_per_snp_r2(self,**args):
-        self.data = _get_per_snp_r2(self.data, beta="BETA", af="EAF", n="N", log=self.log, **args)
+    def get_per_snp_r2(self,**kwargs):
+        self.data = _get_per_snp_r2(self.data, beta="BETA", af="EAF", n="N", log=self.log, **kwargs)
         #add data inplace
 
-    def get_gc(self, mode=None, **args):
+    def get_gc(self, mode=None, **kwargs):
         if mode is None:
             if "P" in self.data.columns:
-                output = lambdaGC(self.data[["CHR","P"]],mode="P",**args)
+                output = lambdaGC(self.data[["CHR","P"]],mode="P",**kwargs)
             elif "Z" in self.data.columns:
-                output = lambdaGC(self.data[["CHR","Z"]],mode="Z",**args)
+                output = lambdaGC(self.data[["CHR","Z"]],mode="Z",**kwargs)
             elif "CHISQ" in self.data.columns:
-                output = lambdaGC(self.data[["CHR","CHISQ"]],mode="CHISQ",**args)
+                output = lambdaGC(self.data[["CHR","CHISQ"]],mode="CHISQ",**kwargs)
             elif "MLOG10P" in self.data.columns:
-                output = lambdaGC(self.data[["CHR","MLOG10P"]],mode="MLOG10P",**args)
+                output = lambdaGC(self.data[["CHR","MLOG10P"]],mode="MLOG10P",**kwargs)
             
             #return scalar
             self.meta["Genomic inflation factor"] = output
             return output    
         else:
-            output = lambdaGC(self.data[["CHR",mode]],mode=mode,**args)
+            output = lambdaGC(self.data[["CHR",mode]],mode=mode,**kwargs)
             self.meta["Genomic inflation factor"] = output
             return output 
 ## LDSC ##############################################################################################
-    def estimate_h2_by_ldsc(self, build=None, verbose=True, match_allele=True, **args):
+    def estimate_h2_by_ldsc(self, build=None, verbose=True, match_allele=True, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
         insumstats = gethapmap3(self.data.copy(), build=build, verbose=verbose , match_allele=True, how="right" )
-        self.ldsc_h2 = _estimate_h2_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **args)
+        self.ldsc_h2 = _estimate_h2_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **kwargs)
     
-    def estimate_rg_by_ldsc(self, build=None, verbose=True, match_allele=True, **args):
+    def estimate_rg_by_ldsc(self, build=None, verbose=True, match_allele=True, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
         insumstats = gethapmap3(self.data.copy(), build=build, verbose=verbose , match_allele=True, how="right" )
-        self.ldsc_rg = _estimate_rg_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **args)
+        self.ldsc_rg = _estimate_rg_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **kwargs)
 
-    def estimate_h2_cts_by_ldsc(self, build=None, verbose=True, match_allele=True, **args):
+    def estimate_h2_cts_by_ldsc(self, build=None, verbose=True, match_allele=True, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
         insumstats = gethapmap3(self.data.copy(), build=build, verbose=verbose , match_allele=True, how="right" )
-        self.ldsc_h2_cts  = _estimate_h2_cts_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **args)
+        self.ldsc_h2_cts  = _estimate_h2_cts_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **kwargs)
     
-    def estimate_partitioned_h2_by_ldsc(self, build=None, verbose=True, match_allele=True, **args):
+    def estimate_partitioned_h2_by_ldsc(self, build=None, verbose=True, match_allele=True, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
         insumstats = gethapmap3(self.data.copy(), build=build, verbose=verbose , match_allele=True, how="right" )
-        self.ldsc_partitioned_h2_summary, self.ldsc_partitioned_h2_results  = _estimate_partitioned_h2_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **args)
+        self.ldsc_partitioned_h2_summary, self.ldsc_partitioned_h2_results  = _estimate_partitioned_h2_by_ldsc(insumstats=insumstats, log=self.log, verbose=verbose, **kwargs)
 # external ################################################################################################
     
-    def calculate_ld_matrix(self,**args):
-        self.to_finemapping_file_path, self.to_finemapping_file, self.plink_log  = tofinemapping(self.data,study = self.meta["gwaslab"]["study_name"],**args)
+    def calculate_ld_matrix(self,**kwargs):
+        self.to_finemapping_file_path, self.to_finemapping_file, self.plink_log  = tofinemapping(self.data,study = self.meta["gwaslab"]["study_name"],**kwargs)
     
-    def run_susie_rss(self,**args):
-        self.pipcs=_run_susie_rss(self.to_finemapping_file_path,**args)
+    def run_susie_rss(self,**kwargs):
+        self.pipcs=_run_susie_rss(self.to_finemapping_file_path,**kwargs)
     
-    def clump(self,**args):
-        self.clumps,self.plink_log = _clump(self.data, log=self.log, study = self.meta["gwaslab"]["study_name"], **args)
+    def clump(self,**kwargs):
+        self.clumps,self.plink_log = _clump(self.data, log=self.log, study = self.meta["gwaslab"]["study_name"], **kwargs)
 
-    def calculate_prs(self,**args):
-        combined_results_summary = _calculate_prs(self.data, log=self.log, study = self.meta["gwaslab"]["study_name"], **args)
+    def calculate_prs(self,**kwargs):
+        combined_results_summary = _calculate_prs(self.data, log=self.log, study = self.meta["gwaslab"]["study_name"], **kwargs)
         return combined_results_summary
     
 # to_format ###############################################################################################       
 
-    def to_format(self, path, build=None, **args):
+    def to_format(self, path, build=None, verbose=True, **kwargs):
         if build is None:
             build = self.meta["gwaslab"]["genome_build"]
-        _to_format(self.data, path, log=self.log, meta=self.meta, build=build, **args)
+        _to_format(self.data, path, log=self.log, verbose=verbose, meta=self.meta, build=build, **kwargs)

--- a/src/gwaslab/g_SumstatsPair.py
+++ b/src/gwaslab/g_SumstatsPair.py
@@ -135,46 +135,46 @@ class SumstatsPair( ):
         return molded_sumstats, sumstats1
 
 
-    def clump(self,**args):
-        self.clumps["clumps"], self.clumps["plink_log"] = _clump(self.data, log=self.log, p="P_1",mlog10p="MLOG10P_1", study = self.study_name, **args)
+    def clump(self,**kwargs):
+        self.clumps["clumps"], self.clumps["plink_log"] = _clump(self.data, log=self.log, p="P_1",mlog10p="MLOG10P_1", study = self.study_name, **kwargs)
 
-    def to_coloc(self,**args):
-        self.to_finemapping_file_path, self.plink_log = tofinemapping(self.data,study=self.study_name,suffixes=self.suffixes,log=self.log,**args)
+    def to_coloc(self,**kwargs):
+        self.to_finemapping_file_path, self.plink_log = tofinemapping(self.data,study=self.study_name,suffixes=self.suffixes,log=self.log,**kwargs)
 
-    def run_coloc_susie(self,**args):
+    def run_coloc_susie(self,**kwargs):
 
-        self.colocalization = _run_coloc_susie(self.to_finemapping_file_path,log=self.log,ncols=self.ns,**args)
+        self.colocalization = _run_coloc_susie(self.to_finemapping_file_path,log=self.log,ncols=self.ns,**kwargs)
 
-    def run_two_sample_mr(self, clump=False, **args):
+    def run_two_sample_mr(self, clump=False, **kwargs):
         exposure1 = self.study_name.split("_")[0]
         outcome2 = self.study_name.split("_")[1]
-        _run_two_sample_mr(self,exposure1=exposure1,outcome2=outcome2, clump=clump,**args)
+        _run_two_sample_mr(self,exposure1=exposure1,outcome2=outcome2, clump=clump,**kwargs)
 
     def extract_with_ld_proxy(self,**arg):
         return _extract_with_ld_proxy(common_sumstats = self.data, sumstats1=self.sumstats1,  **arg)
 
-    def filter_value(self, expr, inplace=False, **args):
+    def filter_value(self, expr, inplace=False, **kwargs):
         if inplace is False:
             new_Sumstats_object = copy.deepcopy(self)
-            new_Sumstats_object.data = filtervalues(new_Sumstats_object.data,expr,log=new_Sumstats_object.log, **args)
+            new_Sumstats_object.data = filtervalues(new_Sumstats_object.data,expr,log=new_Sumstats_object.log, **kwargs)
             return new_Sumstats_object
         else:
-            self.data = filtervalues(self.data, expr,log=self.log,**args)
+            self.data = filtervalues(self.data, expr,log=self.log,**kwargs)
         gc.collect()
 
     ## Visualization #############################################################################################################################################
-    def plot_miami(self,**args):
+    def plot_miami(self,**kwargs):
 
         plot_miami2(merged_sumstats=self.data, 
                     suffixes=self.suffixes,
-                    **args)
+                    **kwargs)
     
-    def compare_af(self, **args):
+    def compare_af(self, **kwargs):
         
         return plotdaf( self.data,
                      eaf="EAF_2",
                      raf="EAF_1",
                      xlabel="Effect Allele Frequency in Sumstats 1",
                      ylabel="Effect Allele Frequency in Sumstats 2",
-                     **args)
+                     **kwargs)
                      

--- a/src/gwaslab/io_read_tabular.py
+++ b/src/gwaslab/io_read_tabular.py
@@ -3,30 +3,30 @@ from gwaslab.bd_common_data import get_formats_list
 from gwaslab.g_Log import Log
 from gwaslab.bd_common_data import get_format_dict
 
-def _read_tabular(path, fmt, **args):
+def _read_tabular(path, fmt, **kwargs):
     
     # default
     load_args_dict = {"sep":"\t",
                       "header":None}
     
     # if specified by user
-    if len(args)>0:
-        load_args_dict = args
+    if len(kwargs)>0:
+        load_args_dict = kwargs
     
     # load format
     meta_data, rename_dictionary = get_format_dict(fmt)
     
-    if "format_separator" in meta_data and "sep" not in args:
+    if "format_separator" in meta_data and "sep" not in kwargs:
         load_args_dict["sep"] = meta_data["format_separator"]
     
-    if "format_comment" in meta_data and "comment" not in args:
+    if "format_comment" in meta_data and "comment" not in kwargs:
         if  meta_data["format_comment"] is not None:    
             load_args_dict["comment"] = meta_data["format_comment"]
 
-    if "format_header" in meta_data and "header" not in args:
+    if "format_header" in meta_data and "header" not in kwargs:
         load_args_dict["header"] = meta_data["format_header"]
 
-    if "format_na" in meta_data and "na_values" not in args:
+    if "format_na" in meta_data and "na_values" not in kwargs:
         if  meta_data["format_na"] is not None:    
             load_args_dict["na_values"] = meta_data["format_na"]
 

--- a/src/gwaslab/io_to_pickle.py
+++ b/src/gwaslab/io_to_pickle.py
@@ -13,7 +13,7 @@ def dump_pickle(glsumstats,path="~/mysumstats.pickle",overwrite=False):
         with open(path, 'wb') as file:
             glsumstats.log.write(" -Dump the Sumstats Object to : ", path)
             pickle.dump(glsumstats, file)
-    Log().write("Finished dumping.")
+    glsumstats.log.write("Finished dumping.")
 
 def load_pickle(path):
     if os.path.exists(path):

--- a/src/gwaslab/qc_fix_sumstats.py
+++ b/src/gwaslab/qc_fix_sumstats.py
@@ -1532,7 +1532,7 @@ def start_to(sumstats,
              ref_fasta=None,
              n_cores=None,
              ref_tsv=None,
-             **args
+             **kwargs
              ):
     
     log.write("Start to {}...{}".format(start_line,_get_version()), verbose=verbose)
@@ -1557,7 +1557,7 @@ def start_to(sumstats,
                 log.write(" -Reference TSV: {}".format(ref_tsv))
             
             is_args_valid = True
-            for key, value in args.items():
+            for key, value in kwargs.items():
                 is_args_valid = is_args_valid & check_arg(log, verbose, key, value, start_function)
             is_enough_col = is_args_valid & is_enough_col
 

--- a/src/gwaslab/util_ex_calculate_ldmatrix.py
+++ b/src/gwaslab/util_ex_calculate_ldmatrix.py
@@ -27,7 +27,7 @@ def tofinemapping(sumstats,
                   log=Log(),
                   suffixes=None,
                   verbose=True,
-                  **args):
+                  **kwargs):
     ##start function with col checking##########################################################
     _start_line = "calculate LD matrix"
     _end_line = "calculating LD matrix"
@@ -84,7 +84,7 @@ def tofinemapping(sumstats,
                                                                     n_cores=n_cores, 
                                                                     log=log,
                                                                     load_bim=True,
-                                                                    overwrite=overwrite,**args)
+                                                                    overwrite=overwrite,**kwargs)
 
         ## check available snps with reference file
         matched_sumstats = _align_sumstats_with_bim(row=row, 

--- a/src/gwaslab/util_ex_calculate_prs.py
+++ b/src/gwaslab/util_ex_calculate_prs.py
@@ -18,7 +18,7 @@ def _calculate_prs(sumstats,
           memory=None, 
           overwrite=False,
           mode=None,delete=True,
-          log=Log(),**args):
+          log=Log(),**kwargs):
     
     #matching_alleles
         #read_bim
@@ -37,7 +37,7 @@ def _calculate_prs(sumstats,
                                                                     n_cores=n_cores, 
                                                                     log=log,
                                                                     load_bim=False,
-                                                                    overwrite=overwrite,**args)
+                                                                    overwrite=overwrite,**kwargs)
         score_file_path_list =[]
         for index, chrom in enumerate(chrlist): 
             chr_sumstats = sumstats.loc[sumstats["CHR"]==chrom,:].copy()

--- a/src/gwaslab/util_ex_ldsc.py
+++ b/src/gwaslab/util_ex_ldsc.py
@@ -11,243 +11,243 @@ from gwaslab.util_in_filter_value import filtervalues
 from gwaslab.util_in_filter_value import _filter_palindromic
 
 class ARGS():
-    def __init__(self, **args):
+    def __init__(self, **kwargs):
         
         self.out = "ldsc"
 
-        if "bfile" in args.keys():
-            self.bfile = args["bfile"]
+        if "bfile" in kwargs.keys():
+            self.bfile = kwargs["bfile"]
         else:
             self.bfile = None 
         
-        if "l2" in args.keys():
-            self.l2 = args["l2"]
+        if "l2" in kwargs.keys():
+            self.l2 = kwargs["l2"]
         else:
             self.l2 = None 
 
-        if "extract" in args.keys():
-            self.extract = args["extract"]
+        if "extract" in kwargs.keys():
+            self.extract = kwargs["extract"]
         else:
             self.extract = None 
 
-        if "keep" in args.keys():
-            self.keep = args["keep"]
+        if "keep" in kwargs.keys():
+            self.keep = kwargs["keep"]
         else:
             self.keep = None 
 
-        if "ld_wind_snps" in args.keys():
-            self.ld_wind_snps = args["ld_wind_snps"]
+        if "ld_wind_snps" in kwargs.keys():
+            self.ld_wind_snps = kwargs["ld_wind_snps"]
         else:
             self.ld_wind_snps = None 
 
-        if "ld_wind_kb" in args.keys():
-            self.ld_wind_kb = args["ld_wind_kb"]
+        if "ld_wind_kb" in kwargs.keys():
+            self.ld_wind_kb = kwargs["ld_wind_kb"]
         else:
             self.ld_wind_kb = None 
 
-        if "ld_wind_cm" in args.keys():
-            self.ld_wind_cm = args["ld_wind_cm"]
+        if "ld_wind_cm" in kwargs.keys():
+            self.ld_wind_cm = kwargs["ld_wind_cm"]
         else:
             self.ld_wind_cm = None 
 
-        if "print_snps" in args.keys():
-            self.print_snps = args["print_snps"]
+        if "print_snps" in kwargs.keys():
+            self.print_snps = kwargs["print_snps"]
         else:
             self.print_snps = None 
 
-        if "annot" in args.keys():
-            self.annot = args["annot"]
+        if "annot" in kwargs.keys():
+            self.annot = kwargs["annot"]
         else:
             self.annot = None 
 
-        if "thin_annot" in args.keys():
-            self.thin_annot = args["thin_annot"]
+        if "thin_annot" in kwargs.keys():
+            self.thin_annot = kwargs["thin_annot"]
         else:
             self.thin_annot = None 
 
-        if "cts_bin" in args.keys():
-            self.cts_bin = args["cts_bin"]
+        if "cts_bin" in kwargs.keys():
+            self.cts_bin = kwargs["cts_bin"]
         else:
             self.cts_bin = None 
 
-        if "cts_breaks" in args.keys():
-            self.cts_breaks = args["cts_breaks"]
+        if "cts_breaks" in kwargs.keys():
+            self.cts_breaks = kwargs["cts_breaks"]
         else:
             self.cts_breaks = None 
 
-        if "cts_names" in args.keys():
-            self.cts_names = args["cts_names"]
+        if "cts_names" in kwargs.keys():
+            self.cts_names = kwargs["cts_names"]
         else:
             self.cts_names = None 
 
-        if "per_allele" in args.keys():
-            self.per_allele = args["per_allele"]
+        if "per_allele" in kwargs.keys():
+            self.per_allele = kwargs["per_allele"]
         else:
             self.per_allele = None 
 
-        if "pq_exp" in args.keys():
-            self.pq_exp = args["pq_exp"]
+        if "pq_exp" in kwargs.keys():
+            self.pq_exp = kwargs["pq_exp"]
         else:
             self.pq_exp = None 
 
-        if "no_print_annot" in args.keys():
-            self.no_print_annot = args["no_print_annot"]
+        if "no_print_annot" in kwargs.keys():
+            self.no_print_annot = kwargs["no_print_annot"]
         else:
             self.no_print_annot = None 
 
-        if "h2" in args.keys():
-            self.h2 = args["h2"]
+        if "h2" in kwargs.keys():
+            self.h2 = kwargs["h2"]
         else:
             self.h2 = None
 
-        if "h2_cts" in args.keys():
-            self.h2_cts = args["h2_cts"]
+        if "h2_cts" in kwargs.keys():
+            self.h2_cts = kwargs["h2_cts"]
         else:
             self.h2_cts = None
 
-        if "rg" in args.keys():
-            self.rg = args["rg"]
+        if "rg" in kwargs.keys():
+            self.rg = kwargs["rg"]
         else:
             self.rg = None
 
-        if "ref_ld" in args.keys():
-            self.ref_ld = args["ref_ld"]
+        if "ref_ld" in kwargs.keys():
+            self.ref_ld = kwargs["ref_ld"]
         else:
             self.ref_ld = None
 
-        if "ref_ld_chr" in args.keys():
-            self.ref_ld_chr = args["ref_ld_chr"]
+        if "ref_ld_chr" in kwargs.keys():
+            self.ref_ld_chr = kwargs["ref_ld_chr"]
         else:
             self.ref_ld_chr = None
 
-        if "w_ld" in args.keys():
-            self.w_ld = args["w_ld"]
+        if "w_ld" in kwargs.keys():
+            self.w_ld = kwargs["w_ld"]
         else:
             self.w_ld = None
         
-        if "w_ld_chr" in args.keys():
-            self.w_ld_chr = args["w_ld_chr"]
+        if "w_ld_chr" in kwargs.keys():
+            self.w_ld_chr = kwargs["w_ld_chr"]
         else:
             self.w_ld_chr = None     
 
-        if "overlap_annot" in args.keys():
-            self.overlap_annot = args["overlap_annot"]
+        if "overlap_annot" in kwargs.keys():
+            self.overlap_annot = kwargs["overlap_annot"]
         else:
             self.overlap_annot = None 
 
-        if "print_coefficients" in args.keys():
-            self.print_coefficients = args["print_coefficients"]
+        if "print_coefficients" in kwargs.keys():
+            self.print_coefficients = kwargs["print_coefficients"]
         else:
             self.print_coefficients = "ldsc" 
 
-        if "frqfile" in args.keys():
-            self.frqfile = args["frqfile"]
+        if "frqfile" in kwargs.keys():
+            self.frqfile = kwargs["frqfile"]
         else:
             self.frqfile = None 
 
-        if "frqfile_chr" in args.keys():
-            self.frqfile_chr = args["frqfile_chr"]
+        if "frqfile_chr" in kwargs.keys():
+            self.frqfile_chr = kwargs["frqfile_chr"]
         else:
             self.frqfile_chr = None 
 
-        if "no_intercept" in args.keys():
-            self.no_intercept = args["no_intercept"]
+        if "no_intercept" in kwargs.keys():
+            self.no_intercept = kwargs["no_intercept"]
         else:
             self.no_intercept = None 
 
-        if "intercept_h2" in args.keys():
-            self.intercept_h2 = args["intercept_h2"]
+        if "intercept_h2" in kwargs.keys():
+            self.intercept_h2 = kwargs["intercept_h2"]
         else:
             self.intercept_h2 = None 
 
-        if "intercept_gencov" in args.keys():
-            self.intercept_gencov = args["intercept_gencov"]
+        if "intercept_gencov" in kwargs.keys():
+            self.intercept_gencov = kwargs["intercept_gencov"]
         else:
             self.intercept_gencov = None 
 
-        if "M" in args.keys():
-            self.M = args["M"]
+        if "M" in kwargs.keys():
+            self.M = kwargs["M"]
         else:
             self.M = None 
 
-        if "two_step" in args.keys():
-            self.two_step = args["two_step"]
+        if "two_step" in kwargs.keys():
+            self.two_step = kwargs["two_step"]
         else:
             self.two_step = None 
 
-        if "chisq_max" in args.keys():
-            self.chisq_max = args["chisq_max"]
+        if "chisq_max" in kwargs.keys():
+            self.chisq_max = kwargs["chisq_max"]
         else:
             self.chisq_max= None 
 
-        if "ref_ld_chr_cts" in args.keys():
-            self.ref_ld_chr_cts = args["ref_ld_chr_cts"]
+        if "ref_ld_chr_cts" in kwargs.keys():
+            self.ref_ld_chr_cts = kwargs["ref_ld_chr_cts"]
         else:
             self.ref_ld_chr_cts = None
 
-        if "print_all_cts" in args.keys():
-            self.print_all_cts = args["print_all_cts"]
+        if "print_all_cts" in kwargs.keys():
+            self.print_all_cts = kwargs["print_all_cts"]
         else:
             self.print_all_cts = False 
 
-        if "print_cov" in args.keys():
-            self.print_cov = args["print_cov"]
+        if "print_cov" in kwargs.keys():
+            self.print_cov = kwargs["print_cov"]
         else:
             self.print_cov = None 
 
         self.print_delete_vals = False
-        if "print_delete_vals" in args.keys():
-            self.print_delete_vals = args["print_delete_vals"]
+        if "print_delete_vals" in kwargs.keys():
+            self.print_delete_vals = kwargs["print_delete_vals"]
         else:
             self.print_delete_vals = False 
 
-        if "chunk_size" in args.keys():
-            self.chunk_size = args["chunk_size"]
+        if "chunk_size" in kwargs.keys():
+            self.chunk_size = kwargs["chunk_size"]
         else:
             self.chunk_size = 50 
 
-        if "pickle" in args.keys():
-            self.pickle = args["pickle"]
+        if "pickle" in kwargs.keys():
+            self.pickle = kwargs["pickle"]
         else:
             self.pickle = False 
 
-        if "yes_really" in args.keys():
-            self.yes_really = args["yes_really"]
+        if "yes_really" in kwargs.keys():
+            self.yes_really = kwargs["yes_really"]
         else:
             self.yes_really = False 
 
-        if "invert_anyway" in args.keys():
-            self.invert_anyway = args["invert_anyway"]
+        if "invert_anyway" in kwargs.keys():
+            self.invert_anyway = kwargs["invert_anyway"]
         else:
             self.invert_anyway = False 
 
-        if "n_blocks" in args.keys():
-            self.n_blocks = args["n_blocks"]
+        if "n_blocks" in kwargs.keys():
+            self.n_blocks = kwargs["n_blocks"]
         else:
             self.n_blocks = 200 
 
-        if "not_M_5_50" in args.keys():
-            self.not_M_5_50 = args["not_M_5_50"]
+        if "not_M_5_50" in kwargs.keys():
+            self.not_M_5_50 = kwargs["not_M_5_50"]
         else:
             self.not_M_5_50 = False 
 
-        if "no_check_alleles" in args.keys():
-            self.no_check_alleles = args["no_check_alleles"]
+        if "no_check_alleles" in kwargs.keys():
+            self.no_check_alleles = kwargs["no_check_alleles"]
         else:
             self.no_check_alleles = False 
         
-        if "return_silly_things" in args.keys():
-            self.return_silly_things = args["return_silly_things"]
+        if "return_silly_things" in kwargs.keys():
+            self.return_silly_things = kwargs["return_silly_things"]
         else:
             self.return_silly_things = False 
 
-        if "samp_prev" in args.keys():
-            self.samp_prev = args["samp_prev"]
+        if "samp_prev" in kwargs.keys():
+            self.samp_prev = kwargs["samp_prev"]
         else:
             self.samp_prev = None 
         
-        if "pop_prev" in args.keys():
-            self.pop_prev = args["pop_prev"]
+        if "pop_prev" in kwargs.keys():
+            self.pop_prev = kwargs["pop_prev"]
         else:
             self.pop_prev = None 
 
@@ -255,7 +255,7 @@ class ARGS():
 ####################################################################################################################
 
 
-def _estimate_h2_by_ldsc(insumstats, log, verbose=True, munge=False, **args):
+def _estimate_h2_by_ldsc(insumstats, log, verbose=True, munge=False, **kwargs):
     sumstats = insumstats.copy()
     
     if munge:
@@ -288,9 +288,9 @@ def _estimate_h2_by_ldsc(insumstats, log, verbose=True, munge=False, **args):
 
 
     log.write(" -Arguments:", verbose=verbose)
-    for key, value in args.items():
+    for key, value in kwargs.items():
         log.write("  -{}:{}".format(key, value), verbose=verbose)
-    default_args = ARGS(**args)
+    default_args = ARGS(**kwargs)
 
     if "Z" not in sumstats.columns:
         sumstats["Z"] = sumstats["BETA"]/sumstats["SE"]
@@ -307,7 +307,7 @@ def _estimate_h2_by_ldsc(insumstats, log, verbose=True, munge=False, **args):
 
 ####################################################################################################################
 
-def _estimate_partitioned_h2_by_ldsc(insumstats, log, verbose=True, **args):
+def _estimate_partitioned_h2_by_ldsc(insumstats, log, verbose=True, **kwargs):
     sumstats = insumstats.copy()
     ##start function with col checking##########################################################
     _start_line = "run LD score regression"
@@ -331,10 +331,10 @@ def _estimate_partitioned_h2_by_ldsc(insumstats, log, verbose=True, **args):
     log.write("  -Please cite LDSC: Bulik-Sullivan, et al. LD Score Regression Distinguishes Confounding from Polygenicity in Genome-Wide Association Studies. Nature Genetics, 2015.", verbose=verbose)
     log.write(" -Arguments:", verbose=verbose)
     
-    for key, value in args.items():
+    for key, value in kwargs.items():
         log.write("  -{}:{}".format(key, value), verbose=verbose)
     
-    default_args = ARGS(**args)
+    default_args = ARGS(**kwargs)
 
     if "Z" not in sumstats.columns:
         sumstats["Z"] = sumstats["BETA"]/sumstats["SE"]
@@ -353,7 +353,7 @@ def _estimate_partitioned_h2_by_ldsc(insumstats, log, verbose=True, **args):
 
 
 
-def _estimate_rg_by_ldsc(insumstats, other_traits ,log, verbose=True, **args):
+def _estimate_rg_by_ldsc(insumstats, other_traits ,log, verbose=True, **kwargs):
     sumstats = insumstats.copy()
     ##start function with col checking##########################################################
     _start_line = "run LD score regression for genetic correlation"
@@ -377,10 +377,10 @@ def _estimate_rg_by_ldsc(insumstats, other_traits ,log, verbose=True, **args):
     log.write("  -Please cite LDSC: Bulik-Sullivan, B., et al. An Atlas of Genetic Correlations across Human Diseases and Traits. Nature Genetics, 2015.", verbose=verbose)
     log.write(" -Arguments:", verbose=verbose)
     
-    for key, value in args.items():
+    for key, value in kwargs.items():
         log.write("  -{}:{}".format(key, value), verbose=verbose)
     
-    default_args = ARGS(**args)
+    default_args = ARGS(**kwargs)
 
     if "Z" not in sumstats.columns:
         sumstats["Z"] = sumstats["BETA"]/sumstats["SE"]
@@ -413,7 +413,7 @@ def _estimate_rg_by_ldsc(insumstats, other_traits ,log, verbose=True, **args):
 ####################################################################################################################
 
 
-def _estimate_h2_cts_by_ldsc(insumstats, log, verbose=True, **args):
+def _estimate_h2_cts_by_ldsc(insumstats, log, verbose=True, **kwargs):
     sumstats = insumstats.copy()
     ##start function with col checking##########################################################
     _start_line = "run LD score regression"
@@ -437,10 +437,10 @@ def _estimate_h2_cts_by_ldsc(insumstats, log, verbose=True, **args):
     log.write("  -Please cite LDSC: Finucane, H. K., Reshef, Y. A., Anttila, V., Slowikowski, K., Gusev, A., Byrnes, A., ... & Price, A. L. (2018). Heritability enrichment of specifically expressed genes identifies disease-relevant tissues and cell types. Nature genetics, 50(4), 621-629.", verbose=verbose)
     log.write(" -Arguments:", verbose=verbose)
     
-    for key, value in args.items():
+    for key, value in kwargs.items():
         log.write("  -{}:{}".format(key, value), verbose=verbose)
     
-    default_args = ARGS(**args)
+    default_args = ARGS(**kwargs)
 
     if "Z" not in sumstats.columns:
         sumstats["Z"] = sumstats["BETA"]/sumstats["SE"]
@@ -456,7 +456,7 @@ def _estimate_h2_cts_by_ldsc(insumstats, log, verbose=True, **args):
 
 
 
-def _munge_sumstats(sumstats, log, verbose=True, **args):
+def _munge_sumstats(sumstats, log, verbose=True, **kwargs):
 
     # filter_info
     sumstats = filtervalues(sumstats, 'INFO >=0.9' ,verbose=verbose, log=log)

--- a/src/gwaslab/util_ex_plink_filter.py
+++ b/src/gwaslab/util_ex_plink_filter.py
@@ -16,10 +16,10 @@ def _run_plink_filter(filter_flag, out_prefix):
     --out {}
     '''.format(filter_flag, out_prefix)
 
-def _plink2_filter_to_flag(tmpdir="./",**args):
+def _plink2_filter_to_flag(tmpdir="./",**kwargs):
     combined_flag=""
     temp_file_list=[]
-    for flag_with_underbar,value in args.items():
+    for flag_with_underbar,value in kwargs.items():
         if isinstance(value, pd.DataFrame) or isinstance(value, pd.Series):
             formated_flag, temp_file = _process_df_to_file(flag_with_underbar=flag_with_underbar,
                                                            df=value,

--- a/src/gwaslab/util_in_filter_value.py
+++ b/src/gwaslab/util_in_filter_value.py
@@ -274,7 +274,7 @@ def inferbuild(sumstats,status="STATUS",chrom="CHR", pos="POS", ea="EA", nea="NE
     finished(log,verbose,_end_line)
     return sumstats, inferred_build
 
-def sampling(sumstats,n=1, p=None, verbose=True,log=Log(),**args):
+def sampling(sumstats,n=1, p=None, verbose=True,log=Log(),**kwargs):
 
     log.write("Start to randomly select variants from the sumstats...", verbose=verbose) 
     if p is None:
@@ -289,17 +289,17 @@ def sampling(sumstats,n=1, p=None, verbose=True,log=Log(),**args):
         else:
             raise ValueError("Please input a number in (0,1)")
     
-    if "random_state" in args.keys():
-        log.write(" -Random state (seed): {}".format(args["random_state"]), verbose=verbose)
+    if "random_state" in kwargs.keys():
+        log.write(" -Random state (seed): {}".format(kwargs["random_state"]), verbose=verbose)
     else:
-        args["random_state"] = np.random.randint(0,4294967295)
-        log.write(" -Random state (seed): {}".format(args["random_state"]), verbose=verbose)
-    sampled = sumstats.sample(n=n,**args)
+        kwargs["random_state"] = np.random.randint(0,4294967295)
+        log.write(" -Random state (seed): {}".format(kwargs["random_state"]), verbose=verbose)
+    sampled = sumstats.sample(n=n,**kwargs)
     log.write("Finished sampling...", verbose=verbose)
     gc.collect()
     return sampled
 
-def _get_flanking(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(),**args):
+def _get_flanking(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(),**kwargs):
     
     log.write("Start to extract variants in the flanking regions:",verbose=verbose)
     log.write(" - Central variant: {}".format(snpid))
@@ -320,7 +320,7 @@ def _get_flanking(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(),**ar
 
     return flanking
 
-def _get_flanking_by_id(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(),**args):
+def _get_flanking_by_id(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(),**kwargs):
     
     log.write("Start to extract variants in the flanking regions using rsID or SNPID...",verbose=verbose)
     log.write(" - Central variants: {}".format(snpid), verbose=verbose)
@@ -359,7 +359,7 @@ def _get_flanking_by_id(sumstats, snpid, windowsizekb=500, verbose=True,log=Log(
 
     return flanking
 
-def _get_flanking_by_chrpos(sumstats, chrpos, windowsizekb=500, verbose=True,log=Log(),**args):
+def _get_flanking_by_chrpos(sumstats, chrpos, windowsizekb=500, verbose=True,log=Log(),**kwargs):
     
     log.write("Start to extract variants in the flanking regions using CHR and POS...",verbose=verbose)
     log.write(" - Central positions: {}".format(chrpos), verbose=verbose)


### PR DESCRIPTION
- In some methods, the `self.log` object was not passed to the inner functions as log `argument`, resulting in the creation of a new `Log` object
- `**args` actually represented named arguments, which traditionally are indicated with `**kwargs`

Also, I think you should bump the version to 3.4.42 (or even better 3.4.43) in the pyproject.toml and g_version.py files :)