### PR TITLE
add fix ID before assign rsID

### DIFF
--- a/src/gwaslab/g_Sumstats.py
+++ b/src/gwaslab/g_Sumstats.py
@@ -390,7 +390,7 @@ class Sumstats():
             
             gc.collect()
             
-        if ref_seq is not None or ref_infer is not None:
+        if (ref_seq is not None or ref_infer is not None) and (ref_rsid_tsv is not None or ref_rsid_vcf is not None):
 
             self.data = fixID(self.data, log=self.log, **{"fixid":True, "fixsep":True, "overwrite":True})
 

--- a/src/gwaslab/g_Sumstats.py
+++ b/src/gwaslab/g_Sumstats.py
@@ -389,6 +389,12 @@ class Sumstats():
             self.data =flipallelestats(self.data,log=self.log,**flipallelestats_args)
             
             gc.collect()
+            
+        if ref_seq is not None or ref_infer is not None:
+
+            self.data = fixID(self.data, log=self.log, **{"fixid":True, "fixsep":True, "overwrite":True})
+
+            gc.collect()
         
         #####################################################
         if ref_rsid_tsv is not None:


### PR DESCRIPTION
Currently g_Sumstats.harmonize only calls fix ID in the basic_check. The SNPIDs are not updated following check ref and infer strand, so when assigning rsIDs, it uses the old, non ref aligned, non strand inferred SNPIDs to try and map rsIDs. One simple fix is to overwrite the SNPIDs prior to assigning rsIDs.