### PR TITLE
Fix minor typos in docs

### DIFF
--- a/docs/SumstatsObject.md
+++ b/docs/SumstatsObject.md
@@ -101,7 +101,7 @@ You can load the sumstats by specifying the columns like:
 
 GWASLab supports common sumstats formats and you can load sumstats by specifying `fmt`.  
     
-GWASLab uses a manually curated format conversion dictionary in [https://github.com/Cloufield/formatbook](https:/github.com/Cloufield/formatbook). Currently, it supports the following formats:
+GWASLab uses a manually curated format conversion dictionary in [https://github.com/Cloufield/formatbook](https://github.com/Cloufield/formatbook). Currently, it supports the following formats:
 
 | `Keyword`     | `Description`        |
 |---------------|----------------------|

--- a/docs/SumstatsObject.md
+++ b/docs/SumstatsObject.md
@@ -121,7 +121,7 @@ GWASLab uses a manually curated format conversion dictionary in [https://github.
 | `vcf`         | gwas-vcf format      |
 | `bolt_lmm`    | output format        |
 
-!!! info "Update Formatbook using `gl.update_formaybook()`"
+!!! info "Update Formatbook using `gl.update_formatbook()`"
     ```python
     gl.update_formatbook()
     Mon Jul 17 17:38:11 2023 Updating formatbook from: https://raw.github.com/Cloufield/formatbook/main/formatbook.json


### PR DESCRIPTION
- A missing slash in `https://` was making the link to the formatbook not work.
- changed `update_formaybook` to `update_formatbook`.