### PR TITLE
Add LDAK summary-statistics format

### DIFF
--- a/src/gwaslab/data/formatbook.json
+++ b/src/gwaslab/data/formatbook.json
@@ -4156,6 +4156,40 @@
             "SNP": "SNPID"
         }
     },
+    "ldak": {
+        "meta_data": {
+            "format_name": "ldak",
+            "format_source": "https://dougspeed.com/summary-statistics/",
+            "format_version": "20260801",
+            "format_cite_name": "LDAK/SumHer",
+            "format_description": "LDAK/SumHer summary statistics with Predictor, A1, A2, n, and either Z or BETA plus SE; A1Freq is recommended.",
+            "format_separator": "\t",
+            "format_na": null,
+            "format_comment": null,
+            "format_header": true,
+            "format_col_order": [
+                "Predictor",
+                "A1",
+                "A2",
+                "Z",
+                "BETA",
+                "SE",
+                "n",
+                "A1Freq"
+            ],
+            "last_check_date": "20260801"
+        },
+        "format_dict": {
+            "Predictor": "SNPID",
+            "A1": "EA",
+            "A2": "NEA",
+            "Z": "Z",
+            "BETA": "BETA",
+            "SE": "SE",
+            "n": "N",
+            "A1Freq": "EAF"
+        }
+    },
     "plink_fam": {
         "meta_data": {
             "format_name": ".fam",

--- a/test/test_io_to_formats.py
+++ b/test/test_io_to_formats.py
@@ -267,6 +267,96 @@ class TestIOToFormats(unittest.TestCase):
             pd.DataFrame.to_csv = old_to_csv
 
 
+class TestLDAKFormat(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp(prefix="tmp_io_ldak_")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _export(self, name, statistics):
+        data = {
+            "SNPID": ["variant_1", "variant_2"],
+            "CHR": [1, 2],
+            "POS": [100, 200],
+            "EA": ["G", "T"],
+            "NEA": ["A", "C"],
+            "N": [1000, 900],
+        }
+        data.update(statistics)
+        column_args = {
+            "snpid": "SNPID",
+            "chrom": "CHR",
+            "pos": "POS",
+            "ea": "EA",
+            "nea": "NEA",
+            "n": "N",
+        }
+        for column, argument in {
+            "Z": "z",
+            "BETA": "beta",
+            "SE": "se",
+            "EAF": "eaf",
+        }.items():
+            if column in data:
+                column_args[argument] = column
+        sumstats = Sumstats(sumstats=pd.DataFrame(data), verbose=False, **column_args)
+        prefix = os.path.join(self.tmpdir, name)
+        sumstats.to_format(prefix, fmt="ldak", gzip=False, verbose=False)
+        return prefix + ".ldak.tsv"
+
+    def test_ldak_export_z_header_order_and_a1freq(self):
+        out_path = self._export(
+            "z",
+            {
+                "Z": [2.5, -1.5],
+                "EAF": [0.25, 0.4],
+            },
+        )
+
+        exported = pd.read_csv(out_path, sep="\t")
+        self.assertListEqual(
+            exported.columns.tolist(),
+            ["Predictor", "A1", "A2", "Z", "n", "A1Freq"],
+        )
+        self.assertListEqual(exported["Predictor"].tolist(), ["variant_1", "variant_2"])
+
+    def test_ldak_export_beta_se_header_order_without_a1freq(self):
+        out_path = self._export(
+            "beta_se",
+            {
+                "BETA": [0.1, -0.2],
+                "SE": [0.01, 0.02],
+            },
+        )
+
+        exported = pd.read_csv(out_path, sep="\t")
+        self.assertListEqual(
+            exported.columns.tolist(),
+            ["Predictor", "A1", "A2", "BETA", "SE", "n"],
+        )
+        self.assertNotIn("A1Freq", exported.columns)
+
+    def test_ldak_roundtrip_preserves_generic_predictor_as_snpid(self):
+        out_path = self._export(
+            "roundtrip",
+            {
+                "Z": [2.5, -1.5],
+                "EAF": [0.25, 0.4],
+            },
+        )
+
+        imported = Sumstats(sumstats=out_path, fmt="ldak", verbose=False)
+        expected_columns = {"SNPID", "EA", "NEA", "Z", "N", "EAF"}
+        self.assertTrue(expected_columns.issubset(imported.data.columns))
+        self.assertNotIn("rsID", imported.data.columns)
+        self.assertListEqual(
+            imported.data["SNPID"].astype(str).tolist(),
+            ["variant_1", "variant_2"],
+        )
+        self.assertListEqual(imported.data["N"].tolist(), [1000, 900])
+
+
 class TestPExportUnderflow(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp(prefix="tmp_io_p_underflow_")


### PR DESCRIPTION
## Summary

- add an `ldak` formatbook preset for LDAK/SumHer summary statistics
- support `Z` and `BETA`/`SE` statistic representations
- preserve optional `A1Freq` and generic `Predictor` identifiers
- add focused export and round-trip tests

## Format contract

The preset maps GWASLab's canonical columns to LDAK's case-sensitive headers: `SNPID -> Predictor`, `EA -> A1`, `NEA -> A2`, `N -> n`, and `EAF -> A1Freq`. `Predictor` imports as `SNPID` rather than assuming rsID semantics.

## Checks

- `python -m json.tool src/gwaslab/data/formatbook.json` passed
- focused pytest cases were added; local execution was not available because the current checkout environment lacks pandas